### PR TITLE
Fix broker provision instance err format

### DIFF
--- a/pkg/brokerapi/types.go
+++ b/pkg/brokerapi/types.go
@@ -25,3 +25,8 @@ type WorkerResponse struct {
 	Message interface{}
 	Err     error
 }
+
+type BrokerErrorResponse struct {
+	Error 		string	`json:"error"`
+	Description string	`json:"description"`
+}

--- a/pkg/controller/base_controller.go
+++ b/pkg/controller/base_controller.go
@@ -196,13 +196,13 @@ func (c *BaseController) CreateServiceInstance(instanceId, serviceID, planID str
 	if instanceGet != nil {
 		switch instanceGet.Status {
 		case StateProvisionInstanceInProgress:
-			return fmt.Errorf("request of provisioning instance %s already exists, which is in progress", instanceId)
+			return fmt.Errorf("duplicated provisioning request of instance %s. It is in progress", instanceId)
 		case StateProvisionInstanceFailed:
-			return fmt.Errorf("request of provisioning instance %s already exists, which was failed", instanceId)
+			return fmt.Errorf("duplicated provisioning request of instance %s. It was failed", instanceId)
 		case StateProvisionInstanceSucceeded:
-			return fmt.Errorf("request of provisioning instance %s already exists, which was succeeded", instanceId)
+			return fmt.Errorf("duplicated provisioning request of instance %s. It was succeeded", instanceId)
 		}
-		return fmt.Errorf("duplicated request of provisioning instance. %v", instanceGet)
+		return fmt.Errorf("duplicated provisioning request of instance. %v", instanceGet)
 	}
 	brokerName, broker := c.GetServiceBroker(serviceID)
 	instanceInfo := new(InstanceRunInfo)

--- a/pkg/controller/base_controller.go
+++ b/pkg/controller/base_controller.go
@@ -163,7 +163,7 @@ func (c *BaseController) getBrokerByName(brokerName string) brokerapi.ServiceBro
 
 type BindRunInfo struct {
 	BindingId string
-	Status    string //provisioning provisioned binding binded
+	Status    string
 	Parameter map[string]interface{}
 }
 
@@ -172,7 +172,7 @@ type InstanceRunInfo struct {
 	ServiceID  string
 	PlanID     string
 	Bindings   map[string]*BindRunInfo
-	Status     string //provisioning provisioned binding binded
+	Status     string
 	BrokerName string
 	Parameter  map[string]interface{}
 }
@@ -194,7 +194,15 @@ func (c *BaseController) CreateServiceInstance(instanceId, serviceID, planID str
 	parameterIn map[string]interface{}) error {
 	instanceGet := c.asyncEngine.GetAsyncInstance(instanceId)
 	if instanceGet != nil {
-		return fmt.Errorf("Instance %s already exist when create instance %s.", instanceId, instanceGet)
+		switch instanceGet.Status {
+		case StateProvisionInstanceInProgress:
+			return fmt.Errorf("request of provisioning instance %s already exists, which is in progress", instanceId)
+		case StateProvisionInstanceFailed:
+			return fmt.Errorf("request of provisioning instance %s already exists, which was failed", instanceId)
+		case StateProvisionInstanceSucceeded:
+			return fmt.Errorf("request of provisioning instance %s already exists, which was succeeded", instanceId)
+		}
+		return fmt.Errorf("duplicated request of provisioning instance. %v", instanceGet)
 	}
 	brokerName, broker := c.GetServiceBroker(serviceID)
 	instanceInfo := new(InstanceRunInfo)
@@ -222,7 +230,7 @@ func (c *BaseController) CreateServiceInstance(instanceId, serviceID, planID str
 		mergeParameter(parameterIn, parameterOut)
 		err = c.asyncEngine.UpdateAsyncInstance(instanceInfo)
 		if err != nil {
-			glog.Infof("CreateAliBrokerInstance  CreateAliBrokerInstance err:%v", err)
+			glog.Infof("UpdateAsyncInstance err: %v", err)
 			return err
 		}
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -150,7 +150,7 @@ func (s *server) getServiceInstanceLastOperation(w http.ResponseWriter, r *http.
 	serviceID := q.Get("service_id")
 	planID := q.Get("plan_id")
 	operation := q.Get("operation")
-	glog.Infof("GetServiceInstance ... %s\n", instanceID)
+	glog.Infof("getServiceInstanceLastOperation ... %s\n", instanceID)
 
 	var req brokerapi.LastOperationRequest
 
@@ -207,10 +207,10 @@ func (s *server) createServiceInstance(w http.ResponseWriter, r *http.Request) {
 	response := <-sChan
 	glog.Infof("Service broker server createServiceInstance get response:%v.\n", response)
 	if response.Err == nil {
-		result := &brokerapi.CreateServiceInstanceResponse{Operation: string(brokerapi.StateInProgress)}
+		result := &brokerapi.CreateServiceInstanceResponse{Operation: response.Message.(string)}
 		util.WriteResponse(w, http.StatusAccepted, result)
 	} else {
-		util.WriteErrorResponse(w, http.StatusBadRequest, response.Err)
+		util.WriteErrorResponse(w, http.StatusConflict, response.Err)
 	}
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -210,7 +210,7 @@ func (s *server) createServiceInstance(w http.ResponseWriter, r *http.Request) {
 		result := &brokerapi.CreateServiceInstanceResponse{Operation: response.Message.(string)}
 		util.WriteResponse(w, http.StatusAccepted, result)
 	} else {
-		util.WriteErrorResponse(w, http.StatusConflict, response.Err)
+		util.WriteErrorResponse(w, http.StatusBadRequest, response.Err)
 	}
 }
 

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -32,7 +32,6 @@ func WriteResponse(w http.ResponseWriter, code int, object interface{}) {
 // using the 'code' as the HTTP status code
 func WriteErrorResponse(w http.ResponseWriter, code int, err error) {
 	WriteResponse(w, code, &brokerapi.BrokerErrorResponse{
-		Error:	     err.Error(),
 		Description: err.Error(),
 	})
 }

--- a/pkg/util/utils.go
+++ b/pkg/util/utils.go
@@ -3,6 +3,7 @@ package util
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/AliyunContainerService/open-service-broker-alibabacloud/pkg/brokerapi"
 	"io/ioutil"
 	"net/http"
 	"os/exec"
@@ -26,15 +27,13 @@ func WriteResponse(w http.ResponseWriter, code int, object interface{}) {
 	w.Write(data)
 }
 
-// WriteErrorResponse will serialize 'object' to the HTTP ResponseWriter
+// WriteErrorResponse will serialize 'err' to the HTTP ResponseWriter
 // with JSON formatted error response
 // using the 'code' as the HTTP status code
 func WriteErrorResponse(w http.ResponseWriter, code int, err error) {
-	type e struct {
-		Error string
-	}
-	WriteResponse(w, code, &e{
-		Error: err.Error(),
+	WriteResponse(w, code, &brokerapi.BrokerErrorResponse{
+		Error:	     err.Error(),
+		Description: err.Error(),
 	})
 }
 


### PR DESCRIPTION
format broker provision instance error message according to go-open-service-broker client lib.
consolidate http response status code to 400(badrequest) for vary request info errors, like duplicated request to provision same instance.